### PR TITLE
add productFromDiagonalMatrix method

### DIFF
--- a/src/AI-LinearAlgebra-Tests/AIDiagonalMatrixTest.class.st
+++ b/src/AI-LinearAlgebra-Tests/AIDiagonalMatrixTest.class.st
@@ -27,3 +27,18 @@ AIDiagonalMatrixTest >> testDimension [
 	self assert: m columnSize equals: 5.
 
 ]
+
+{ #category : #tests }
+AIDiagonalMatrixTest >> testproductFromDiagonalMatrix [
+
+
+	| aDiagonalMatrix aRowMatrix|
+	aDiagonalMatrix := AIDiagonalMatrix withDiagonal: #(1 2).
+	aRowMatrix := AIRowMatrix new rows: #( #(5 3) #(3 2)).
+	aDiagonalMatrix := aDiagonalMatrix * aRowMatrix.
+	self assert: (aDiagonalMatrix at: 1 and: 1) equals: 5.
+	self assert: (aDiagonalMatrix at: 1 and: 2) equals: 0.
+	self assert: (aDiagonalMatrix at: 2 and: 1) equals: 0.
+	self assert: (aDiagonalMatrix at: 2 and: 2) equals: 4.
+
+]

--- a/src/AI-LinearAlgebra/AIDiagonalMatrix.class.st
+++ b/src/AI-LinearAlgebra/AIDiagonalMatrix.class.st
@@ -23,6 +23,14 @@ AIDiagonalMatrix class >> withDiagonal: vector [
 	^newMatrix
 ]
 
+{ #category : #arithmetic }
+AIDiagonalMatrix >> * aMatrixOrNumber [
+	
+			
+	
+	^ aMatrixOrNumber productFromDiagonalMatrix: self.
+]
+
 { #category : #accessing }
 AIDiagonalMatrix >> at: row and: column [
 	

--- a/src/AI-LinearAlgebra/AIMatrix.class.st
+++ b/src/AI-LinearAlgebra/AIMatrix.class.st
@@ -744,6 +744,15 @@ AIMatrix >> printOn: aStream [
 ]
 
 { #category : #'double dispatching' }
+AIMatrix >> productFromDiagonalMatrix: aDiagonalMatrix [
+	
+	  1 to: aDiagonalMatrix rowSize do: [:i|
+		aDiagonalMatrix at: i and: i put: (aDiagonalMatrix at:i and: i)*(self at: i and: i ) ].
+
+	  ^aDiagonalMatrix 
+]
+
+{ #category : #'double dispatching' }
 AIMatrix >> productFromDouble: aNumber [
 	
 	^self productFromNumber: aNumber


### PR DESCRIPTION
Previously, when we perform the element-wise multiplication of AIDiagonalMatrix with another matrix, we never took into account that only diagonal elements have to be multiplied as other elements would anyway be zero.

This PR introduces a new method `productFromDiagonalMatrix` that multiplies only the diagonal elements of the argument(AIDiagonalmatrix) with the receiver(AIMatrix) and returns the argument.